### PR TITLE
Fix Next.js v14 export command breaking change

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -5,6 +5,7 @@ const nextConfig = {
   images: {
     unoptimized: true,
   },
+  output: "export",
 }
 
 module.exports = nextConfig

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "next-start": "cross-env BROWSER=none next dev",
-    "next-build": "next build && next export",
+    "next-build": "next build",
     "tauri": "tauri",
     "build": "tauri build",
     "dev": "tauri dev",


### PR DESCRIPTION
In nextjs v14 they removed the export command and replaced it with `output: "export"` option in next.config.js

https://nextjs.org/docs/pages/building-your-application/deploying/static-exports
![CleanShot 2023-10-29 at 02 20 59@2x](https://github.com/kvnxiao/tauri-nextjs-template/assets/17254073/121153a3-4029-42b7-8ae1-bb380aa280a8)
